### PR TITLE
Bump to 1.2.2

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -34,3 +34,5 @@ jobs:
         run: ./rebar3 do xref, dialyzer
       - name: Run eunit
         run: ./rebar3 as gha do eunit
+      - name: Run broader tests
+        run: make test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,5 +1,5 @@
 export LEVELDB_VSN ?= "openriak-3.2"
-SNAPPY_VSN ?= "1.1.9"
+SNAPPY_VSN ?= "1.2.2"
 BASEDIR = $(shell pwd)
 
 export LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
@@ -47,4 +47,4 @@ clean:
 	rm -rf system snappy-$(SNAPPY_VSN)/build
 
 test: compile
-	$(MAKE) CXXFLAGS="$(CXXFLAGS) -Wno-narrowing" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -Wno-narrowing -std=c++11" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test


### PR DESCRIPTION
Sett CXXFLAGS in test to use c++11.  Required for OSX.  erlang.yml updated to see if this works on ubuntu-latest - may need to be OSX specific