### PR TITLE
unbreak freebsd build

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,8 +21,8 @@ compile: get-deps snappy ldb
 	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
 
 ldb:
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
 snappy: system/lib/libsnappy.a
 
@@ -31,7 +31,7 @@ system/lib/libsnappy.a:
 	(cd snappy-$(SNAPPY_VSN) && \
 	 git submodule update --init && \
 	 if [ -r autogen.sh ]; then \
-	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && make && make install; \
+	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && $(MAKE) && $(MAKE) install; \
 	 else \
 	   mkdir build && cd build && \
 	   mkdir -p $(BASEDIR)/system && \
@@ -39,7 +39,7 @@ system/lib/libsnappy.a:
 	         -D CMAKE_INSTALL_PREFIX=$(BASEDIR)/system \
 	     ..; \
 	  fi && \
-	  make && make install)
+	  $(MAKE) && $(MAKE) install)
 	mv system/lib64 system/lib || true
 
 clean:

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -36,6 +36,7 @@ system/lib/libsnappy.a:
 	   mkdir build && cd build && \
 	   mkdir -p $(BASEDIR)/system && \
 	   cmake -D SNAPPY_BUILD_TESTS=0 -D SNAPPY_BUILD_BENCHMARKS=0 \
+	         -D CMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	         -D CMAKE_INSTALL_PREFIX=$(BASEDIR)/system \
 	     ..; \
 	  fi && \

--- a/rebar.config
+++ b/rebar.config
@@ -32,10 +32,10 @@
              {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lstdc++"}
              ]}.
 
-{pre_hooks, [{'get-deps', "make -C c_src get-deps"},
-             {compile, "make -C c_src compile"}]}.
+{pre_hooks, [{'get-deps', "gmake -C c_src get-deps"},
+             {compile, "gmake -C c_src compile"}]}.
 
-{post_hooks, [{clean, "make -C c_src clean"}]}.
+{post_hooks, [{clean, "gmake -C c_src clean"}]}.
 
 {profiles, [
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}


### PR DESCRIPTION
* `gmake` instead of `make`;
* explicitly add `-lpthread` to `LDFLAGS` when linking leveldb.

With the above, build succeeded on FreeBSD 14.2-RELEASE.

* Also, not freebsd-specific, add `-D CMAKE_POLICY_VERSION_MINIMUM=3.5` in call to cmake, which is necessary (and sufficient) to re-enable building snappy-1.1.9 with cmake-4.x.